### PR TITLE
fatal error fixed on function datecmp

### DIFF
--- a/main.c
+++ b/main.c
@@ -85,15 +85,15 @@ void datecmp()
     printf("date compare\n");
 
     time1 = localtime(&stat1.st_mtime);
-    tm_year1 = (time1->tm_year + 1900) * 365;
+    // tm_year1 = (time1->tm_year + 1900) * 365;
     tm_day1 = time1->tm_yday;
 
     time2 = localtime(&stat2.st_mtime);
-    tm_year2 = (time2->tm_year + 1900) * 365;
+    // tm_year2 = (time2->tm_year + 1900) * 365;
     tm_day2 = time2->tm_yday;
 
-    result1 = tm_year1 + tm_day1;
-    result2 = tm_year2 + tm_day2;
+    result1 = tm_day1;
+    result2 = tm_day2;
 
     if (result1 < result2)
     {


### PR DESCRIPTION
함수 7번(datecmp)에 년도를 비교하는 충격적이고 비참한(tragedy) 오류가 있었습니다.
마땅히 받아야할 비판을 받고 속세를 벗어나겠습니다.
감사합니다.